### PR TITLE
collapsing comments fix

### DIFF
--- a/hn.css
+++ b/hn.css
@@ -137,7 +137,6 @@ td.subtext a:hover {
 /*********** Vote Arrows ****************/
 
 tr>td>center>a {
-	padding: 4px;
 	vertical-align: bottom;
 	opacity: 0.8;
 	position: relative;


### PR DESCRIPTION
Fixing a bug where the comments that follow a comment X mistakenly seem like X's children, and collapsing X collapses the comments that follow X.
Example: Second comment from the top at http://news.ycombinator.com/item?id=375821 and its children.
