### PR TITLE
Added ability to temporarily suppress the endless loading feature

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -6,6 +6,7 @@ var hn = {
 	identelem: null,
 	endless_loading: false,
 	endless_preload: 200,
+	endless_suppress: false,
 	
 	init: function(){
 	
@@ -109,6 +110,12 @@ var hn = {
 		
 		$(document).click(hn.closeQuickReply);
 		$(document).scroll(hn.checkPageEnd);
+		$(document).keydown(function(ev) {
+			if(ev.which == 27) hn.endless_suppress = true;
+		});
+		$(document).keyup(function(ev) {
+			if(ev.which == 27) hn.endless_suppress = false;
+		});
 	},
 	
 	shareStory: function(element, url, title){
@@ -150,6 +157,7 @@ var hn = {
 	
 	loadNextPage: function(){
 	
+		if(hn.endless_suppress) return;
 		hn.endless_loading = true;
 		
 		var $temp = $('<div/>');


### PR DESCRIPTION
Endless loading has one issue, and that is it prevents you from being able to use HN's search feature. I added a small feature to suppress endless loading if you hold down the Escape key when scrolling to the end. This allows you to use the search box again.
