### PR TITLE
Add proper CSS font stack for pretty fallbacks

### DIFF
--- a/hn.css
+++ b/hn.css
@@ -9,6 +9,26 @@ table {
 }
 
 
+/*********** Fonts *******************/
+
+body,
+td,
+.admin td,
+.subtext td,
+input[type=\"submit\"],
+.default,
+.admin,
+.title,
+.adtitle,
+.subtext,
+.yclinks,
+.pagetop,
+.comhead,
+.comment,
+.dead {
+	font-family: Verdana, Geneva, sans-serif !important;
+}
+
 /*********** Header ******************/
 
 table table a[href='http://ycombinator.com'] img {


### PR DESCRIPTION
Many Linux distros don't package Verdana so this change overrides
the default font's outlined in ycombinator/news.css providing prettier
fallbacks.

I wasn't a massive fan of having to override the styles in news.css but it seems the only the way, perhaps I should submit this PR directly to pg? :)
