### PR TITLE
Fix filters count display bug

### DIFF
--- a/hn.css
+++ b/hn.css
@@ -107,12 +107,10 @@ table table a[href='http://ycombinator.com'] img {
 }
 
 #menu-filters .count {
-	display: block;
-	position: absolute;
-	min-width: 6px;
-	top: -1px;
-	left: -16px;
+	position: relative;
 	padding: 1px 3px;
+	right: 4px;
+	top: -1px;
 	background: #2279B2;
 	font-size: 10px;
 	color: #fff;

--- a/js/hn.js
+++ b/js/hn.js
@@ -63,7 +63,7 @@ var hn = {
 	},
 	
 	createFilterMenu: function(){
-		$('.pagetop').last().prepend('<a id="menu-filters">filters<span class="count"></span></a> | ');
+		$('.pagetop').last().prepend('<a id="menu-filters"><span class="count"></span>filters</a> | ');
 		$('.pagetop').parents('tr').first().after('<tr><td colspan="3" id="filter-wrapper"><em></em><input type="text" id="add-filter" placeholder="Add a term or phrase to filter" /><p class="empty">Add a filter on the right to no longer see it on HN.</p><ul id="current-filters"></ul></td></tr>');
 		hn.refreshFilters();
 	},


### PR DESCRIPTION
Hi, thanks for the great extension!

I noticed a display bug in the filter count when it's over 10:
![bug](http://i.imgur.com/Snl1Kiv.png)

So I put the `<span>` before `filters` and set the position to `relative`, it should look good in all occasions now.
![fixed](http://i.imgur.com/IsEojiM.png)
